### PR TITLE
Update database for customer links and address codes

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -45,3 +45,12 @@ mongorestore --uri "$MONGODB_URI" backups/
 - Passwords are hashed using `bcryptjs` before storing.
 - JWT tokens are signed with `JWT_SECRET` and should be kept private.
 - Limit database access to trusted hosts and use strong credentials.
+
+## New Features
+
+- **Addresses table**: stores provinces, districts and wards for the address selection feature.
+- **Users table**: new `email_verified` flag for registration confirmation.
+- **Customers table**: links to `users` via `user_id`.
+- **Orders table**: keeps detailed shipping location codes (province, district, ward) and the `shipper` fields.
+
+Seed data for these additions can be found in `sample_data.sql`.

--- a/database/docs/ERD.dot
+++ b/database/docs/ERD.dot
@@ -1,10 +1,11 @@
 digraph ERD {
   rankdir=LR;
   node [shape=record];
-  Users [label="{Users|+id: SERIAL PK\l+username: VARCHAR\l+email: VARCHAR\l+password: VARCHAR\l+role: VARCHAR}"];
+  Users [label="{Users|+id: SERIAL PK\l+username: VARCHAR\l+email: VARCHAR\l+password: VARCHAR\l+role: VARCHAR\l+email_verified: BOOL}"];
   Products [label="{Products|+id: SERIAL PK\l+name: VARCHAR\l+price: NUMERIC\l+stock: INT}"];
-  Customers [label="{Customers|+id: SERIAL PK\l+name: VARCHAR\l+email: VARCHAR}"];
-  Orders [label="{Orders|+id: SERIAL PK\l+order_number: VARCHAR\l+customer_id: FK\l+total_amount: NUMERIC}"];
+  Customers [label="{Customers|+id: SERIAL PK\l+name: VARCHAR\l+email: VARCHAR\l+user_id: FK}"];
+  Orders [label="{Orders|+id: SERIAL PK\l+order_number: VARCHAR\l+customer_id: FK\l+shipper: VARCHAR\l+province_code: FK\l+district_code: FK\l+ward_code: FK\l+total_amount: NUMERIC}"];
+  Addresses [label="{Addresses|+code: PK\l+name: VARCHAR\l+level: INT\l+parent_code: FK}"];
   OrderItems [label="{OrderItems|+order_id: FK\l+product_id: FK\l+quantity: INT}"];
   Reviews [label="{Reviews|+id: SERIAL PK\l+product_id: FK\l+user_id: FK\l+rating: INT}"];
   SalesEvents [label="{SalesEvents|+id: SERIAL PK\l+title: VARCHAR}"];
@@ -21,6 +22,7 @@ digraph ERD {
   Users -> Reviews [label="1..*", arrowhead=crow];
   Users -> Messages [label="1..*", arrowhead=crow];
   Users -> Messages [label="1..*", dir=back];
+  Addresses -> Addresses [label="1", dir=back, arrowhead=crow];
   SalesEvents -> SalesEventProducts [label="1..*", arrowhead=crow];
   Products -> SalesEventProducts [label="1..*", arrowhead=crow];
   Users -> Challenges [label="1..*", arrowhead=crow];

--- a/database/sample_data.sql
+++ b/database/sample_data.sql
@@ -1,28 +1,45 @@
 -- Sample data for Sales Management System
-INSERT INTO users (username, email, password, role, full_name, phone)
+INSERT INTO users (username, email, password, role, full_name, phone, email_verified)
 VALUES
-  ('admin', 'admin@example.com', 'hashed_admin_pwd', 'admin', 'Admin User', '0123456789'),
-  ('user1', 'user@example.com', 'hashed_user_pwd', 'user', 'Nguyen Van A', '0987654321');
+  ('admin', 'admin@example.com', 'hashed_admin_pwd', 'admin', 'Admin User', '0123456789', TRUE),
+  ('user1', 'user@example.com', 'hashed_user_pwd', 'user', 'Nguyen Van A', '0987654321', TRUE),
+  ('shipper1', 'shipper@example.com', 'hashed_shipper_pwd', 'shipper', 'Tran Van Shipper', '0909009009', TRUE);
 
 INSERT INTO products (name, description, price, original_price, discount, stock, category, brand, image, specifications, warranty, sku)
 VALUES
   ('Tủ Lạnh Samsung', 'Tủ lạnh Samsung 300L', 12000000, 15000000, 20, 50, 'kitchen', 'Samsung', '/assets/products/tulanh.jpg', 'Dung tích 300L', '24 tháng', 'SAM-KIT-001'),
   ('Smart TV LG', 'Smart TV 55 inch 4K', 18000000, 22000000, 18, 30, 'livingroom', 'LG', '/assets/products/smarttv.jpg', '55 inch 4K', '24 tháng', 'LG-LIV-002');
 
-INSERT INTO customers (name, email, phone, address)
+INSERT INTO customers (name, email, user_id, phone, address)
 VALUES
-  ('Nguyen Van B', 'customer@example.com', '0911222333', '123 ABC Street');
+  ('Nguyen Van B', 'customer@example.com', 2, '0911222333', '123 ABC Street');
 
-INSERT INTO orders (order_number, customer_id, payment_method, shipping_address, total_amount)
+-- Sample address hierarchy
+INSERT INTO addresses (code, name, full_name, level, parent_code)
 VALUES
-  ('ORD001', 1, 'COD', '123 ABC Street', 0);
+  ('01', 'Hà Nội', 'Thành phố Hà Nội', 1, NULL),
+  ('001', 'Ba Đình', 'Quận Ba Đình', 2, '01'),
+  ('00001', 'Phúc Xá', 'Phường Phúc Xá', 3, '001');
+
+INSERT INTO orders (order_number, customer_id, payment_method, shipping_detail,
+  shipping_province_code, shipping_district_code, shipping_ward_code,
+  shipper, delivery_status, delivered_at, total_amount)
+VALUES
+  ('ORD001', 1, 'COD', '123 ABC Street', '01', '001', '00001', NULL, NULL, NULL, 0),
+  ('ORD002', 1, 'COD', '123 ABC Street', '01', '001', '00001', 'shipper1', 'in_transit', NULL, 0);
 
 INSERT INTO order_items (order_id, product_id, product_name, price, quantity)
 VALUES
   (1, 1, 'Tủ Lạnh Samsung', 12000000, 1),
-  (1, 2, 'Smart TV LG', 18000000, 2);
+  (1, 2, 'Smart TV LG', 18000000, 2),
+  (2, 2, 'Smart TV LG', 18000000, 1);
 
 -- Update total amount for order 1
 UPDATE orders SET total_amount = (
   SELECT SUM(price * quantity) FROM order_items WHERE order_id = 1
 ) WHERE id = 1;
+
+UPDATE orders SET total_amount = (
+  SELECT SUM(price * quantity) FROM order_items WHERE order_id = 2
+) WHERE id = 2;
+

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE users (
     role VARCHAR(20) DEFAULT 'user',
     full_name VARCHAR(100) NOT NULL,
     phone VARCHAR(20),
+    email_verified BOOLEAN DEFAULT FALSE,
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -43,6 +44,7 @@ CREATE TABLE customers (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     email VARCHAR(100) UNIQUE NOT NULL,
+    user_id INTEGER REFERENCES users(id),
     phone VARCHAR(20) NOT NULL,
     address VARCHAR(255) NOT NULL,
     type VARCHAR(20) DEFAULT 'retail',
@@ -65,7 +67,13 @@ CREATE TABLE orders (
     status VARCHAR(50) DEFAULT 'Đang xử lý',
     payment_status VARCHAR(50) DEFAULT 'Chờ thanh toán',
     payment_method VARCHAR(50) NOT NULL,
-    shipping_address VARCHAR(255) NOT NULL,
+    shipping_detail VARCHAR(255) NOT NULL,
+    shipping_province_code VARCHAR(10) REFERENCES addresses(code),
+    shipping_district_code VARCHAR(10) REFERENCES addresses(code),
+    shipping_ward_code VARCHAR(10) REFERENCES addresses(code),
+    shipper VARCHAR(100),
+    delivery_status VARCHAR(50),
+    delivered_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -161,6 +169,21 @@ CREATE TABLE employees (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Address hierarchy (provinces/districts/wards)
+CREATE TABLE addresses (
+    code VARCHAR(10) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    level INTEGER NOT NULL CHECK (level IN (1,2,3)),
+    parent_code VARCHAR(10) REFERENCES addresses(code),
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_addresses_parent ON addresses(parent_code);
+CREATE INDEX idx_addresses_level ON addresses(level);
+
 CREATE TABLE messages (
     id SERIAL PRIMARY KEY,
     from_user INTEGER REFERENCES users(id) ON DELETE CASCADE,
@@ -213,3 +236,6 @@ FOR EACH ROW EXECUTE FUNCTION trg_reduce_stock();
 CREATE INDEX idx_products_name ON products USING gin (to_tsvector('simple', name));
 CREATE INDEX idx_customers_email ON customers(email);
 CREATE INDEX idx_orders_customer_date ON orders(customer_id, date DESC);
+CREATE INDEX idx_orders_shipper ON orders(shipper);
+CREATE INDEX idx_orders_address ON orders(shipping_province_code, shipping_district_code, shipping_ward_code);
+


### PR DESCRIPTION
## Summary
- add `email_verified` to **users** table
- link `customers` to users via `user_id`
- extend `orders` with province/district/ward codes
- update seed data and documentation
- regenerate ERD diagram text

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870d3f03bb0833387aa6b401253b907